### PR TITLE
feat: 카드 생성 로딩 인디케이터 추가

### DIFF
--- a/src/app/(card)/layout.tsx
+++ b/src/app/(card)/layout.tsx
@@ -4,7 +4,7 @@ export default function InfoCardFormLayout({ children }: { children: React.React
   return (
     <Template withNavbar={false}>
       <div className={`viewport h-screen overflow-y-auto overflow-x-hidden`}>
-        <div className="py-36">{children}</div>
+        <div className="py-36 h-full">{children}</div>
       </div>
     </Template>
   );

--- a/src/app/(card)/loading.tsx
+++ b/src/app/(card)/loading.tsx
@@ -1,0 +1,14 @@
+import { flexColCenter } from '@/styles/ogoo/alignment.css';
+import { titleSm } from '@/styles/ogoo/typography.css';
+import { cn } from '@/utils';
+
+export default function Loading() {
+  return (
+    <div className={cn(flexColCenter, 'justify-center h-full')}>
+      <div className="loading-wrapper">
+        <div className="loading-indicator" />
+      </div>
+      <span className={titleSm}>귀여운 펫 카드를 만들고 있어요</span>
+    </div>
+  );
+}

--- a/src/app/(card)/petcard/[[...generation]]/page.tsx
+++ b/src/app/(card)/petcard/[[...generation]]/page.tsx
@@ -1,6 +1,8 @@
 'use client';
 import { redirect, usePathname } from 'next/navigation';
+import { Suspense } from 'react';
 
+import Loading from '../../loading';
 import { PetCardGeneration } from '../components';
 
 export default function PetBusinessCardPage() {
@@ -8,6 +10,10 @@ export default function PetBusinessCardPage() {
   if (pathname != '/petcard') {
     redirect('/petcard');
   } else {
-    return <PetCardGeneration />;
+    return (
+      <Suspense fallback={<Loading />}>
+        <PetCardGeneration />
+      </Suspense>
+    );
   }
 }

--- a/src/app/(card)/petcard/components/PetCardGeneration.tsx
+++ b/src/app/(card)/petcard/components/PetCardGeneration.tsx
@@ -24,7 +24,7 @@ export const PetCardGeneration = () => {
 
   const allStepsCompleted = submitCount === TOTAL_STEPS;
 
-  // TODO: if (allStepsCompleted) /pets/cards 후 리턴받은 response를
+  // TODO: if (allStepsCompleted) /pets/cards POST 후 리턴받은 response를
   // share/${type}?name=${name}&img_url=${img_url}로 넘겨주기
   // (redirect 또는 pushState)
 

--- a/src/app/(card)/petcard/components/PetCardGeneration.tsx
+++ b/src/app/(card)/petcard/components/PetCardGeneration.tsx
@@ -18,6 +18,15 @@ export const PetCardGeneration = () => {
   const [currentStep, setCurrentStep] = useState('1');
 
   const methods = useForm<PetCardFormData>();
+  const {
+    formState: { submitCount },
+  } = methods;
+
+  const allStepsCompleted = submitCount === TOTAL_STEPS;
+
+  // TODO: if (allStepsCompleted) /pets/cards 후 리턴받은 response를
+  // share/${type}?name=${name}&img_url=${img_url}로 넘겨주기
+  // (redirect 또는 pushState)
 
   usePushStateListener(
     useCallback((url) => {

--- a/src/app/(card)/share/businesscard/page.tsx
+++ b/src/app/(card)/share/businesscard/page.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+const ShareBusinessCardPage = () => {
+  // TODO: URL query string으로 type, name, img_url 넘겨받기
+  // URL에 정보가 담겨있어야 주소 공유 시 렌더 가능
+
+  return <div>펫명함 공유 페이지</div>;
+};
+
+export default ShareBusinessCardPage;

--- a/src/app/(card)/share/petcard/page.tsx
+++ b/src/app/(card)/share/petcard/page.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+const SharePetCardPage = () => {
+  // TODO: URL query string으로 type, name, img_url 넘겨받기
+  // URL에 정보가 담겨있어야 주소 공유 시 렌더 가능
+
+  return <div>펫카드 공유 페이지</div>;
+};
+
+export default SharePetCardPage;

--- a/src/components/templates/MainTabView/MainBusinessCardView.tsx
+++ b/src/components/templates/MainTabView/MainBusinessCardView.tsx
@@ -28,8 +28,9 @@ export const MainBusinessCardView = ({ active }: Props) => {
         >
           <Image
             src="/img/bussinesscardFront_example.png"
-            fill
-            sizes="100%"
+            width={146}
+            height={220}
+            style={{ width: 'auto', height: 'auto' }}
             alt=""
             priority
             className="object-cover"
@@ -42,7 +43,9 @@ export const MainBusinessCardView = ({ active }: Props) => {
         >
           <Image
             src="/img/bussinesscardBack_example.png"
-            fill
+            width={146}
+            height={222}
+            style={{ width: 'auto', height: 'auto' }}
             alt=""
             priority
             className="object-cover"

--- a/src/components/templates/MainTabView/MainPetCardView.tsx
+++ b/src/components/templates/MainTabView/MainPetCardView.tsx
@@ -25,11 +25,12 @@ export const MainPetCardView = ({ active }: Props) => {
         >
           <Image
             src="/img/petcard_example_1.png"
-            fill
-            sizes="100%"
+            width={400}
+            height={395}
+            style={{ width: 'auto', height: 'auto' }}
             alt=""
             priority
-            className="object-cover"
+            className="object-cover object-top"
           />
         </picture>
         <div className={cn(bgSub, `sticky bottom-0 left-0 right-0 w-full p-5`)}>

--- a/src/components/templates/ProgressView/ProgressBar.tsx
+++ b/src/components/templates/ProgressView/ProgressBar.tsx
@@ -20,12 +20,13 @@ export const ProgressBar: React.FC<ProgressBarProps> = ({ totalSteps, currentSte
           ></div>
         </div>
         <Image
-          className="absolute duration-300 ease-in-out"
+          className="absolute duration-300 ease-in-out h-auto"
           src="/svg/progressicon.svg"
           alt="progress"
           width={32}
-          height={34}
+          height={37}
           style={{ right: iconPosition, top: '-15px' }}
+          priority
         />
       </div>
     </>

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -15,3 +15,59 @@
   border-radius: 10px;
   background-color: rgba(115, 78, 247, 0.15);
 }
+
+.loading-wrapper {
+  width: 280px;
+  height: 80px;
+  margin: 20px;
+  position: relative;
+}
+
+.loading-indicator {
+  position: relative;
+  margin: 0 auto;
+  width: 36px;
+  height: 50px;
+  background-image: url('/svg/peticon_2.svg');
+  background-repeat: no-repeat;
+  transform: translateY(0%);
+  animation: loading-indicator-center 0.8s ease-in-out alternate infinite;
+  animation-delay: 0.5s;
+}
+.loading-indicator::after,
+.loading-indicator::before {
+  content: '';
+  position: absolute;
+  transform: translateY(0%);
+  width: 36px;
+  height: 50px;
+  animation: loading-indicator-side 0.8s ease-in-out alternate infinite;
+}
+.loading-indicator::before {
+  content: url('/svg/peticon_3.svg');
+  left: -50px;
+  animation-delay: 0.2s;
+}
+.loading-indicator::after {
+  content: url('/svg/peticon_1.svg');
+  right: -50px;
+  animation-delay: 1s;
+}
+
+@keyframes loading-indicator-center {
+  0% {
+    transform: translateY(40%);
+  }
+  100% {
+    transform: translateY(-40%);
+  }
+}
+
+@keyframes loading-indicator-side {
+  0% {
+    transform: translateY(20%);
+  }
+  100% {
+    transform: translateY(-20%);
+  }
+}


### PR DESCRIPTION
https://github.com/fifty-nine-fifty-nine/front/assets/84499458/d9a24a53-8899-413c-9120-e55a6838415f

- 로딩 인디케이터 애니메이션 구현
  - 임시로 tailwind.css에 다 넣어두고 있는데 나중에 분리하겠습니다!
- 아래 warning 안뜨도록 이미지 사이즈 수정
`If you use CSS to change the size of your image, also include the styles 'width: "auto"' or 'height: "auto"' to maintain the aspect ratio.`
- share 라우트랑 구현할 파일들 추가했고, `// TODO:` 주석에 할 일 적어뒀어요! @jong6598 
  - 공유할 때 URL 너무 길어지니깐 나중에 URL 단축 API 쓰면 좋을 것 같아요