### PR TITLE
feat: 펫 카드 공유페이지 구현

### DIFF
--- a/src/app/(card)/petcard/components/views/PetCardDescriptionView.tsx
+++ b/src/app/(card)/petcard/components/views/PetCardDescriptionView.tsx
@@ -23,7 +23,7 @@ export const PetCardDescriptionView = () => {
       return;
     }
     if (data.type && data.name && data.description) {
-      router.push(
+      router.replace(
         `/share/petcard?type=${data.type}&name=${data.name}&description=${data.description}`,
       );
     }

--- a/src/app/(card)/share/petcard/component/PetCardResult.tsx
+++ b/src/app/(card)/share/petcard/component/PetCardResult.tsx
@@ -20,26 +20,30 @@ export const PetCardResult = ({ petCardInfo }: Props) => {
   const searchParams = useSearchParams();
   const pathname = usePathname();
   const router = useRouter();
-  const descriptionRef = useRef<string | null>();
 
   useEffect(() => {
     if (searchParams.get('type')) {
       const name = petCardInfo.name;
-      const imgPath = petCardInfo.img_url.split('/').slice(4).join('/');
-      descriptionRef.current = searchParams.get('description');
-      router.replace(`${pathname}?name=${name}&imgPath=${encodeURIComponent(imgPath)}`);
+      const path = petCardInfo.img_url.split('/').slice(4).join('/');
+      const description = searchParams.get('description')?.replaceAll('%20', ' ') ?? '';
+
+      const replaceUrl = `${pathname}?name=${name}&path=${encodeURIComponent(
+        path,
+      )}&desc=${encodeURIComponent(description)}`;
+
+      router.replace(replaceUrl);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [router, searchParams]);
 
-  if (searchParams.get('imgPath')) {
+  if (searchParams.get('path')) {
     return (
       <>
         <header className={cn(`absolute top-0 left-0 right-0 pt-12 bg-white w-full`)}>
           <StepBackButton />
         </header>
 
-        <div className="h-full flex-col justify-between px-5">
+        <div className="h-full flex-col justify-between px-5 mt-[-40px]">
           <h2 className={cn(titleLg, `mb-3 text-center`)}>펫 카드가 만들어졌어요!</h2>
 
           <article
@@ -50,7 +54,7 @@ export const PetCardResult = ({ petCardInfo }: Props) => {
           >
             <picture className={`w-[400px] h-[274px] relative`}>
               <Image
-                src={`${IMAGE_BASE_URL}${searchParams.get('imgPath')}`}
+                src={`${IMAGE_BASE_URL}${searchParams.get('path')}`}
                 width={350}
                 height={350}
                 alt={`${searchParams.get('name')}의 펫카드`}
@@ -60,7 +64,7 @@ export const PetCardResult = ({ petCardInfo }: Props) => {
 
             <div className={cn(bgSub, `sticky bottom-0 left-0 right-0 w-full p-5`)}>
               <strong className="block mb-1">{searchParams.get('name')}</strong>
-              <p className={subText}>{descriptionRef.current}</p>
+              <p className={subText}>{decodeURIComponent(searchParams.get('desc') ?? '')}</p>
             </div>
           </article>
 
@@ -72,7 +76,7 @@ export const PetCardResult = ({ petCardInfo }: Props) => {
             </button>
           </div>
 
-          <div className={`w-full px-1 my-10`}>
+          <div className={`w-full px-1 py-10`}>
             <strong className={cn(bodyLg, subText, `block pb-2`)}>유의사항</strong>
             <ul className={bulletItem}>
               <li>펫 카드는 생성된 후 마이페이지에 저장되지 않습니다.</li>

--- a/src/app/(card)/share/petcard/component/PetCardResult.tsx
+++ b/src/app/(card)/share/petcard/component/PetCardResult.tsx
@@ -1,18 +1,89 @@
+'use client';
 import Image from 'next/image';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { useEffect, useRef } from 'react';
 
-import type { PetCardResponse } from '@/types';
+import { StepBackButton } from '@/components/templates';
+import { IMAGE_BASE_URL } from '@/constants';
+import { button, buttonHover } from '@/styles/ogoo';
+import { flexColCenter } from '@/styles/ogoo/alignment.css';
+import { bgSub, optionalText, subText, whiteText } from '@/styles/ogoo/colors.css';
+import { bodyLg, bodySm, titleLg, titleSm } from '@/styles/ogoo/typography.css';
+import type { PetCardResponse, PetCardSharedParams } from '@/types';
+import { cn } from '@/utils';
 
-export const PetCardResult = ({ petCardInfo }: { petCardInfo: PetCardResponse }) => {
-  console.log(petCardInfo);
-  return (
-    <div>
-      <p>{petCardInfo.name}완성!</p>
-      <Image
-        src={petCardInfo.img_url}
-        width={350}
-        height={350}
-        alt={`${petCardInfo.name}의 펫카드`}
-      />
-    </div>
-  );
+interface Props {
+  petCardInfo: PetCardResponse & PetCardSharedParams;
+}
+
+export const PetCardResult = ({ petCardInfo }: Props) => {
+  const searchParams = useSearchParams();
+  const pathname = usePathname();
+  const router = useRouter();
+  const descriptionRef = useRef<string | null>();
+
+  useEffect(() => {
+    if (searchParams.get('type')) {
+      const name = petCardInfo.name;
+      const imgPath = petCardInfo.img_url.split('/').slice(4).join('/');
+      descriptionRef.current = searchParams.get('description');
+      router.replace(`${pathname}?name=${name}&imgPath=${encodeURIComponent(imgPath)}`);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [router, searchParams]);
+
+  if (searchParams.get('imgPath')) {
+    return (
+      <>
+        <header className={cn(`absolute top-0 left-0 right-0 pt-12 bg-white w-full`)}>
+          <StepBackButton />
+        </header>
+
+        <div className="h-full flex-col justify-between px-5">
+          <h2 className={cn(titleLg, `mb-3 text-center`)}>펫 카드가 만들어졌어요!</h2>
+
+          <article
+            className={cn(
+              flexColCenter,
+              `relative m-auto mb-6 max-w-[400px] rounded-xl overflow-hidden`,
+            )}
+          >
+            <picture className={`w-[400px] h-[274px] relative`}>
+              <Image
+                src={`${IMAGE_BASE_URL}${searchParams.get('imgPath')}`}
+                width={350}
+                height={350}
+                alt={`${searchParams.get('name')}의 펫카드`}
+                className="min-w-full"
+              />
+            </picture>
+
+            <div className={cn(bgSub, `sticky bottom-0 left-0 right-0 w-full p-5`)}>
+              <strong className="block mb-1">{searchParams.get('name')}</strong>
+              <p className={subText}>{descriptionRef.current}</p>
+            </div>
+          </article>
+
+          <div className="flex-center w-full text-center">
+            <h3 className={titleSm}>공유하기</h3>
+            <div className="mt-2 my-6">공유아이콘들</div>
+            <button className={cn(button({ size: 'sm' }), whiteText, buttonHover, `w-40 m-auto`)}>
+              이미지로 저장
+            </button>
+          </div>
+
+          <div className={`w-full px-1 my-10`}>
+            <strong className={cn(bodyLg, subText, `block pb-2`)}>유의사항</strong>
+            <ul className={bulletItem}>
+              <li>펫 카드는 생성된 후 마이페이지에 저장되지 않습니다.</li>
+              <li>생성된 이미지가 마음에 드셨다면 이미지를 다운로드 해주세요.</li>
+              <li>하루에 n번만 생성 가능합니다.</li>
+            </ul>
+          </div>
+        </div>
+      </>
+    );
+  }
 };
+
+const bulletItem = cn(bodySm, optionalText, `font-normal list-disc list-inside`);

--- a/src/app/(card)/share/petcard/page.tsx
+++ b/src/app/(card)/share/petcard/page.tsx
@@ -3,7 +3,7 @@ import React, { Suspense } from 'react';
 
 import { API_BASE_URL } from '@/constants';
 import { authOptions } from '@/lib/auth';
-import type { PetCardResponse } from '@/types';
+import type { PetCardResponse, PetCardSharedParams } from '@/types';
 
 import Loading from '../../loading';
 import { PetCardResult } from './component/PetCardResult';
@@ -29,7 +29,9 @@ export default async function SharePetCardPage({
       .then((res) => res.json())
       .then((res) => res);
 
-  const petCardInfo: PetCardResponse = genRequired ? await fetchPetCard() : searchParams;
+  const petCardInfo: PetCardResponse & PetCardSharedParams = genRequired
+    ? await fetchPetCard()
+    : searchParams;
 
   return (
     <Suspense fallback={<Loading />}>

--- a/src/components/templates/MainTabView/MainPetCardView.tsx
+++ b/src/components/templates/MainTabView/MainPetCardView.tsx
@@ -30,7 +30,7 @@ export const MainPetCardView = ({ active }: Props) => {
             style={{ width: 'auto', height: 'auto' }}
             alt=""
             priority
-            className="object-cover object-top"
+            className="object-cover object-top min-w-full"
           />
         </picture>
         <div className={cn(bgSub, `sticky bottom-0 left-0 right-0 w-full p-5`)}>

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,1 +1,2 @@
 export const API_BASE_URL = 'https://ogooserver-vqip4fvzbq-uc.a.run.app';
+export const IMAGE_BASE_URL = 'https://oaidalleapiprodscus.blob.core.windows.net/private/';

--- a/src/types/formdatas.ts
+++ b/src/types/formdatas.ts
@@ -29,6 +29,11 @@ export interface PetCardResponse {
   img_url: string;
 }
 
+export interface PetCardSharedParams {
+  name: string;
+  imgPath: string;
+}
+
 export enum AnimalTypeEnum {
   dog = '강아지',
   cat = '고양이',


### PR DESCRIPTION
- 펫카드 생성과정이 히스토리 스택에 남지 않도록 공유(결과)페이지로 router.replace를 통해 이동합니다
- 공유를 위해 url 쿼리스트링을 name, imgPath가 남도록 교체합니다
  - url 공유 시에는 단축 API 사용하면 좋을 것 같아요
- 소셜 공유, 이미지저장 기능은 구현해야합니다!