### PR TITLE
fix: Fix Error that not contain photos when go to the previous page

### DIFF
--- a/src/app/(card)/businesscard/components/views/BusinessCardPetPhotoView.tsx
+++ b/src/app/(card)/businesscard/components/views/BusinessCardPetPhotoView.tsx
@@ -36,7 +36,7 @@ export const BusinessCardPetPhotoView = ({ setBusinessCardFormData }: Props) => 
 
   const fileRef = useRef<HTMLInputElement>(null);
   const [imgFile, setImgFile] = useState<File>();
-  const [uploadedUrl, setUploadedUrl] = useState('');
+  const petProfileImgPath = watch('petProfileImgPath');
 
   const handleClick = () => {
     fileRef.current?.click();
@@ -72,7 +72,6 @@ export const BusinessCardPetPhotoView = ({ setBusinessCardFormData }: Props) => 
       await uploadBytes(storageRef, imgFile);
       const downloadURL = await getDownloadURL(storageRef);
       setValue('petProfileImgPath', downloadURL);
-      setUploadedUrl(downloadURL);
     } catch (err) {
       console.error(err);
     }
@@ -122,11 +121,11 @@ export const BusinessCardPetPhotoView = ({ setBusinessCardFormData }: Props) => 
                       onChange={handleChangeImage}
                     />
 
-                    {uploadedUrl ? (
+                    {petProfileImgPath ? (
                       <div className="w-52 h-52 relative">
                         <div className="absolute inset-0 flex items-center justify-center">
                           <Image
-                            src={uploadedUrl}
+                            src={petProfileImgPath}
                             fill
                             className="object-contain"
                             sizes="(max-width: 208px)"


### PR DESCRIPTION
뒤로가기 버튼 클릭했을 때, 이미지가 유지되지 않던 버그를 해결한 pr 입니다.

#### 원인 

이전에는 uploadedUrl 라는 상태값을 통해 이미지의 유무를 판단했습니다.
```
const [uploadedUrl, setUploadedUrl] = useState('');

{uploadedUrl ? (이미지 가져온다) : (안가져온다)}
```

#### 해결 방법

이제는 watch를 통해 form 내부의 petProfileImgPath 값을 직접 가져와서 이 값의 유무에 따라 이미지의 유무를 판단하도록 수정했습니다.
```
  const petProfileImgPath = watch('petProfileImgPath');

                    {petProfileImgPath ? (
                      <div className="w-52 h-52 relative">
                        <div className="absolute inset-0 flex items-center justify-center">
                          <Image
                            src={petProfileImgPath}
                            fill
                            className="object-contain"
                            sizes="(max-width: 208px)"
                            alt=""
                            priority
                            onClick={handleClick}
                          />
                        </div>
                      </div>
                    ) : (
                      <button
                        type="button"
                        onClick={handleClick}
                        className={cn(bgSub, flexCenter, 'w-32 h-32 rounded-full')}
                      >
                        <p className={cn(optionalText, 'text-[60px] font-light')}>+</p>
                      </button>
                    )}
```